### PR TITLE
fix: enable sticky comments in Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          use_sticky_comment: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Adds `use_sticky_comment: true` to the Claude code review workflow
- Prevents PR comment flooding by editing the previous comment instead of creating new ones

## Test plan
- Workflow configuration validated by pre-commit hooks
- Will be verified on next PR when the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)