### PR TITLE
Fix Claude Code sticky comments by configuring correct bot name

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_sticky_comment: true
+          bot_name: "claude"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Fixes sticky comment feature in claude-code-action workflow by adding `bot_name: "claude"`
- Resolves duplicate comment issue where each workflow run created a new comment instead of updating the existing one

## Problem

The `use_sticky_comment: true` configuration wasn't working, causing the workflow to create duplicate comments on every PR update. Investigation revealed:

1. The action defaults to looking for comments from `claude[bot]` (GitHub App bot account)
2. Actual comments are posted by `claude` (regular user account, ID: 81847)
3. Since the action couldn't find its previous comment, it created a new one each run

## Solution

Added `bot_name: "claude"` to the workflow configuration to tell the action which account to look for when checking for existing sticky comments.

## Test Plan

- ✅ Verified bot account name is "claude" (not "claude[bot]")
- ✅ Confirmed bot_name parameter exists in action inputs
- ✅ Workflow syntax validated by pre-commit hooks
- After merge: Monitor that future PRs only have one claude comment that gets updated instead of duplicated

## Context

Related to [anthropics/claude-code-action#602](https://github.com/anthropics/claude-code-action/issues/602) - known issue with sticky comments not updating properly in v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)